### PR TITLE
Allow custom path/file name for core dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Usage: procdump [OPTIONS...] TARGET
       -I          Polling frequency in milliseconds (default is 1000)
       -n          Number of core dumps to write before exiting (default is 1)
       -s          Consecutive seconds before dump is written (default is 10)
+      -o          Path and/or filename prefix where the core dump is written to
       -d          Writes diagnostic logs to syslog
    TARGET must be exactly one of these:
       -p          pid of the process
@@ -86,6 +87,14 @@ sudo procdump -c 10 -C 65 -p 1234
 The following will create a core dump when CPU usage is >= 65% or memory usage is >= 100 MB.
 ```
 sudo procdump -C 65 -M 100 -p 1234
+```
+The following will create a core dump in the `/tmp` directory immediately.
+```
+sudo procdump -o /tmp -p 1234
+```
+The following will create a core dump in the current directory with the name dump_0.1234. If -n is used, the files will be named dump_0.1234, dump_1.1234 and so on.
+```
+sudo procdump -o dump -p 1234
 ```
 
 > All options can also be used with -w instead of -p. -w will wait for a process with the given name.

--- a/include/ProcDumpConfiguration.h
+++ b/include/ProcDumpConfiguration.h
@@ -25,6 +25,10 @@
 #include <limits.h>
 #include <dirent.h>
 #include <errno.h>
+#include <libgen.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "Handle.h"
 #include "TriggerThreadProcs.h"
@@ -83,6 +87,8 @@ struct ProcDumpConfiguration {
     int ThreadThreshold;            // -T
     int FileDescriptorThreshold;    // -F
     int PollingInterval;            // -I
+    char *CoreDumpPath;             // -o
+    char *CoreDumpName;             // -o
 
     // multithreading
     // set max number of concurrent dumps on init (default to 1)

--- a/procdump.1
+++ b/procdump.1
@@ -14,6 +14,7 @@ procdump [OPTIONS...] TARGET
       -I          Polling frequency in milliseconds (default is 1000)
       -n          Number of core dumps to write before exiting (default is 1)
       -s          Consecutive seconds before dump is written (default is 10)
+      -o          Path and/or filename prefix where the core dump is written to
       -d          Writes diagnostic logs to syslog
   TARGET must be exactly one of these:
       -p   pid of the process

--- a/tests/integration/runProcDumpAndValidate.sh
+++ b/tests/integration/runProcDumpAndValidate.sh
@@ -6,6 +6,11 @@ function runProcDumpAndValidate {
 	dumpDir=$(mktemp -d -t dump_XXXXXX)
 	cd $dumpDir
 
+	dumpParam=""
+	if [ "$#" -ge "6" -a -n "$6" ]; then
+		dumpParam="-o $dumpDir/$6"
+	fi
+
 	if [ -z "$TESTPROGNAME" ]; then
 		if [ "$5" == "MEM" ]; then
 			stress-ng --vm 1 --vm-hang 0 --vm-bytes $1 --timeout 20s -q&
@@ -23,16 +28,16 @@ function runProcDumpAndValidate {
 		childpid=$(echo $childrenpid | cut -d " " -f1)
 		echo "ChildPID: $childpid"
 
-		echo "$PROCDUMPPATH $2 $3 -p $childpid"
-		$PROCDUMPPATH $2 $3 -p $childpid
+		echo "$PROCDUMPPATH $2 $3 $dumpParam -p $childpid"
+		$PROCDUMPPATH $2 $3 $dumpParam -p $childpid
 	else
 		TESTPROGPATH=$(readlink -m "$DIR/../../bin/$TESTPROGNAME");
 		(sleep 2; $TESTPROGPATH "$TESTPROGMODE") &
 		pid=$!
 		echo "PID: $pid"
 
-		echo "$PROCDUMPPATH $2 $3 -w $TESTPROGNAME"
-		$PROCDUMPPATH $2 $3 -w "$TESTPROGNAME"
+		echo "$PROCDUMPPATH $2 $3 $dumpParam -w $TESTPROGNAME"
+		$PROCDUMPPATH $2 $3 $dumpParam -w "$TESTPROGNAME"
 	fi
 
 	if ps -p $pid > /dev/null

--- a/tests/integration/scenarios/high_cpu.sh
+++ b/tests/integration/scenarios/high_cpu.sh
@@ -8,4 +8,4 @@ procDumpType="-C"
 procDumpTrigger=80
 shouldDump=true
 
-runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump "CPU"

--- a/tests/integration/scenarios/high_cpu_by_name.sh
+++ b/tests/integration/scenarios/high_cpu_by_name.sh
@@ -11,4 +11,4 @@ procDumpType="-C"
 procDumpTrigger=50
 shouldDump=true
 
-runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump "CPU"

--- a/tests/integration/scenarios/high_cpu_custom_core_file_name.sh
+++ b/tests/integration/scenarios/high_cpu_custom_core_file_name.sh
@@ -4,8 +4,9 @@ runProcDumpAndValidate=$(readlink -m "$DIR/../runProcDumpAndValidate.sh");
 source $runProcDumpAndValidate
 
 stressPercentage=90
-procDumpType="-M 1000 -C"
+procDumpType="-C"
 procDumpTrigger=80
 shouldDump=true
+customDumpFileName="custom_dump_file"
 
-runProcDumpAndValidate $stressPercentage "$procDumpType" $procDumpTrigger $shouldDump "CPU"
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump "CPU" $customDumpFileName

--- a/tests/integration/scenarios/high_cpu_nonexisting_output_directory.sh
+++ b/tests/integration/scenarios/high_cpu_nonexisting_output_directory.sh
@@ -4,8 +4,9 @@ runProcDumpAndValidate=$(readlink -m "$DIR/../runProcDumpAndValidate.sh");
 source $runProcDumpAndValidate
 
 stressPercentage=90
-procDumpType="-M 1000 -C"
+procDumpType="-C"
 procDumpTrigger=80
-shouldDump=true
+shouldDump=false
+customDumpFileName="missing_subdir/custom_dump_file"
 
-runProcDumpAndValidate $stressPercentage "$procDumpType" $procDumpTrigger $shouldDump "CPU"
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump "CPU" $customDumpFileName

--- a/tests/integration/scenarios/high_cpu_notdump.sh
+++ b/tests/integration/scenarios/high_cpu_notdump.sh
@@ -8,4 +8,4 @@ procDumpType="-C"
 procDumpTrigger=80
 shouldDump=false
 
-runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump "CPU"

--- a/tests/integration/scenarios/low_cpu.sh
+++ b/tests/integration/scenarios/low_cpu.sh
@@ -8,4 +8,4 @@ procDumpType="-c"
 procDumpTrigger=20
 shouldDump=true
 
-runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump "CPU"

--- a/tests/integration/scenarios/low_cpu_by_name.sh
+++ b/tests/integration/scenarios/low_cpu_by_name.sh
@@ -10,4 +10,4 @@ procDumpType="-c"
 procDumpTrigger=20
 shouldDump=true
 
-runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump "CPU"

--- a/tests/integration/scenarios/low_cpu_notdump.sh
+++ b/tests/integration/scenarios/low_cpu_notdump.sh
@@ -8,4 +8,4 @@ procDumpType="-c"
 procDumpTrigger=20
 shouldDump=false
 
-runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump
+runProcDumpAndValidate $stressPercentage $procDumpType $procDumpTrigger $shouldDump "CPU"

--- a/tests/integration/scenarios/low_cpu_trigger_cpu_memory.sh
+++ b/tests/integration/scenarios/low_cpu_trigger_cpu_memory.sh
@@ -8,4 +8,4 @@ procDumpType="-M 1000 -c"
 procDumpTrigger=20
 shouldDump=true
 
-runProcDumpAndValidate $stressPercentage "$procDumpType" $procDumpTrigger $shouldDump
+runProcDumpAndValidate $stressPercentage "$procDumpType" $procDumpTrigger $shouldDump "CPU"

--- a/tests/integration/scenarios/ondemand.sh
+++ b/tests/integration/scenarios/ondemand.sh
@@ -8,4 +8,4 @@ procDumpType=""
 procDumpTrigger=""
 shouldDump=true
 
-runProcDumpAndValidate "$stressPercentage" "$procDumpType" "$procDumpTrigger" "$shouldDump"
+runProcDumpAndValidate "$stressPercentage" "$procDumpType" "$procDumpTrigger" "$shouldDump" "CPU"


### PR DESCRIPTION
This change allows to specify a custom output directory and file name for the generated core dump files. So far, the dumps were always placed in the current directory and had the format `<process name>_<type>_<date>.<pid>`.

Now, using the `-o` command line option, there are the following options:

- if you pass an existing directory or a path that ends in a slash, we use the passed path as the target directory while the name stays in the default format.
- otherwise, the passed string is split up into `directory` and `basename` components, and the core dumps are created in `<directory>` with the name `<basename>_<counter>.<pid>`.

The new test cases check if using a non-existing directory fails and if using a custom file name produces a core dump file in the temp directory created for the test case.

Closes: #100