### PR TITLE
Fixed triggers array overflow

### DIFF
--- a/include/ProcDumpConfiguration.h
+++ b/include/ProcDumpConfiguration.h
@@ -35,7 +35,7 @@
 #include "Process.h"
 #include "Logging.h"
 
-#define MAX_TRIGGERS 3
+#define MAX_TRIGGERS 10
 #define NO_PID INT_MAX
 #define MAX_CMDLINE_LEN 4096+1
 #define EMPTY_PROC_NAME "null"

--- a/src/ProcDumpConfiguration.c
+++ b/src/ProcDumpConfiguration.c
@@ -592,6 +592,7 @@ int CreateTriggerThreads(struct ProcDumpConfiguration *self)
 {    
     int rc = 0;
     self->nThreads = 0;
+    bool tooManyTriggers = false;
 
     if((rc=sigemptyset (&sig_set)) < 0)
     {
@@ -617,31 +618,43 @@ int CreateTriggerThreads(struct ProcDumpConfiguration *self)
 
     // create threads
     if (self->CpuThreshold != -1) {
-        if ((rc = pthread_create(&self->Threads[self->nThreads++ % MAX_TRIGGERS], NULL, CpuMonitoringThread, (void *)self)) != 0) {
-            Trace("CreateTriggerThreads: failed to create CpuThread.");            
-            return rc;
-        }
+        if (self->nThreads < MAX_TRIGGERS) {
+            if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, CpuMonitoringThread, (void *)self)) != 0) {
+                Trace("CreateTriggerThreads: failed to create CpuThread.");            
+                return rc;
+            }
+        } else
+            tooManyTriggers = true;
     }
 
     if (self->MemoryThreshold != -1) {
-        if ((rc = pthread_create(&self->Threads[self->nThreads++ % MAX_TRIGGERS], NULL, CommitMonitoringThread, (void *)self)) != 0) {
-            Trace("CreateTriggerThreads: failed to create CommitThread.");            
-            return rc;
-        }
+        if (self->nThreads < MAX_TRIGGERS) {
+            if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, CommitMonitoringThread, (void *)self)) != 0) {
+                Trace("CreateTriggerThreads: failed to create CommitThread.");            
+                return rc;
+            }
+        } else
+            tooManyTriggers = true;
     }
 
     if (self->ThreadThreshold != -1) {
-        if ((rc = pthread_create(&self->Threads[self->nThreads++ % MAX_TRIGGERS], NULL, ThreadCountMonitoringThread, (void *)self)) != 0) {
-            Trace("CreateTriggerThreads: failed to create ThreadThread.");            
-            return rc;
-        }
+        if (self->nThreads < MAX_TRIGGERS) {
+            if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, ThreadCountMonitoringThread, (void *)self)) != 0) {
+                Trace("CreateTriggerThreads: failed to create ThreadThread.");            
+                return rc;
+            }
+        } else
+            tooManyTriggers = true;
     }
 
     if (self->FileDescriptorThreshold != -1) {
-        if ((rc = pthread_create(&self->Threads[self->nThreads++ % MAX_TRIGGERS], NULL, FileDescriptorCountMonitoringThread, (void *)self)) != 0) {
-            Trace("CreateTriggerThreads: failed to create FileDescriptorThread.");            
-            return rc;
-        }
+        if (self->nThreads < MAX_TRIGGERS) {
+            if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, FileDescriptorCountMonitoringThread, (void *)self)) != 0) {
+                Trace("CreateTriggerThreads: failed to create FileDescriptorThread.");            
+                return rc;
+            }
+        } else
+            tooManyTriggers = true;
     }
 
     if (self->SignalNumber != -1) {
@@ -652,13 +665,16 @@ int CreateTriggerThreads(struct ProcDumpConfiguration *self)
     }
 
     if (self->bTimerThreshold) {
-        if ((rc = pthread_create(&self->Threads[self->nThreads++ % MAX_TRIGGERS], NULL, TimerThread, (void *)self)) != 0) {
-            Trace("CreateTriggerThreads: failed to create TimerThread.");
-            return rc;
-        }
+        if (self->nThreads < MAX_TRIGGERS) {
+            if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, TimerThread, (void *)self)) != 0) {
+                Trace("CreateTriggerThreads: failed to create TimerThread.");
+                return rc;
+            }
+        } else
+            tooManyTriggers = true;
     }
     
-    if (self->nThreads > MAX_TRIGGERS)
+    if (tooManyTriggers)
     {
         Log(error, "Too many triggers.  ProcDump only supports up to %d triggers.", MAX_TRIGGERS);
         return -1;

--- a/src/ProcDumpConfiguration.c
+++ b/src/ProcDumpConfiguration.c
@@ -627,7 +627,7 @@ int CreateTriggerThreads(struct ProcDumpConfiguration *self)
             tooManyTriggers = true;
     }
 
-    if (self->MemoryThreshold != -1) {
+    if (self->MemoryThreshold != -1 && !tooManyTriggers) {
         if (self->nThreads < MAX_TRIGGERS) {
             if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, CommitMonitoringThread, (void *)self)) != 0) {
                 Trace("CreateTriggerThreads: failed to create CommitThread.");            
@@ -637,7 +637,7 @@ int CreateTriggerThreads(struct ProcDumpConfiguration *self)
             tooManyTriggers = true;
     }
 
-    if (self->ThreadThreshold != -1) {
+    if (self->ThreadThreshold != -1 && !tooManyTriggers) {
         if (self->nThreads < MAX_TRIGGERS) {
             if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, ThreadCountMonitoringThread, (void *)self)) != 0) {
                 Trace("CreateTriggerThreads: failed to create ThreadThread.");            
@@ -647,7 +647,7 @@ int CreateTriggerThreads(struct ProcDumpConfiguration *self)
             tooManyTriggers = true;
     }
 
-    if (self->FileDescriptorThreshold != -1) {
+    if (self->FileDescriptorThreshold != -1 && !tooManyTriggers) {
         if (self->nThreads < MAX_TRIGGERS) {
             if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, FileDescriptorCountMonitoringThread, (void *)self)) != 0) {
                 Trace("CreateTriggerThreads: failed to create FileDescriptorThread.");            
@@ -657,14 +657,14 @@ int CreateTriggerThreads(struct ProcDumpConfiguration *self)
             tooManyTriggers = true;
     }
 
-    if (self->SignalNumber != -1) {
+    if (self->SignalNumber != -1 && !tooManyTriggers) {
         if ((rc = pthread_create(&sig_monitor_thread_id, NULL, SignalMonitoringThread, (void *)self)) != 0) {
             Trace("CreateTriggerThreads: failed to create SignalMonitoringThread.");            
             return rc;
         }
     }
 
-    if (self->bTimerThreshold) {
+    if (self->bTimerThreshold && !tooManyTriggers) {
         if (self->nThreads < MAX_TRIGGERS) {
             if ((rc = pthread_create(&self->Threads[self->nThreads++], NULL, TimerThread, (void *)self)) != 0) {
                 Trace("CreateTriggerThreads: failed to create TimerThread.");

--- a/src/ProcDumpConfiguration.c
+++ b/src/ProcDumpConfiguration.c
@@ -6,7 +6,7 @@
 // The global configuration structure and utilities header
 //
 //--------------------------------------------------------------------
-
+ 
 #include "Procdump.h"
 #include "ProcDumpConfiguration.h"
 


### PR DESCRIPTION
Increased MAX_TRIGGERS to 10.  There's currently 5 triggers.  Added error checking in case more than 10 triggers are made inadvertently.  Also used modulo operation to prevent array buffer overflow before we exit.