### PR TITLE
Makefile: add order-only build dependencies on directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,23 +47,23 @@ install:
 	mkdir -p $(DESTDIR)$(MANDIR)
 	cp procdump.1 $(DESTDIR)$(MANDIR)
 
-$(OBJDIR)/%.o: $(SRCDIR)/%.c
+$(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
 	$(CC) -c -g -o $@ $< $(CCFLAGS)
 
-$(OBJDIR)/%.o: $(TESTDIR)/%.c
+$(OBJDIR)/%.o: $(TESTDIR)/%.c | $(OBJDIR)
 	$(CC) -c -g -o $@ $< $(CCFLAGS)
 
-$(OUT): $(OBJS)
+$(OUT): $(OBJS) | $(BINDIR)
 	$(CC) -o $@ $^ $(CCFLAGS)
 
-$(TESTOUT): $(TESTOBJS)
+$(TESTOUT): $(TESTOBJS) | $(BINDIR)
 	$(CC) -o $@ $^ $(CCFLAGS)
 
-$(OBJDIR):
-	-@mkdir -p $(OBJDIR)
+$(OBJDIR): clean
+	-mkdir -p $(OBJDIR)
 
-$(BINDIR):
-	-@mkdir -p $(BINDIR)
+$(BINDIR): clean
+	-mkdir -p $(BINDIR)
 
 .PHONY: clean
 clean:
@@ -77,7 +77,7 @@ test: build
 release: clean tarball
 
 .PHONY: tarball
-tarball:
+tarball: clean
 	$(PKGBUILDROOT_CREATE_CMD)
 	tar --exclude=./pkgbuild --exclude=./.git --transform 's,^\.,procdump-$(PKG_VERSION),' -czf $(BUILDDIR)/SOURCES/procdump-$(PKG_VERSION).tar.gz .
 	sed -e "s/@PKG_VERSION@/$(PKG_VERSION)/g" dist/procdump.spec.in > $(BUILDDIR)/SPECS/procdump.spec


### PR DESCRIPTION
Noticed missing build dependencies when attempted to enable parallelism
on NixOS procdump package. There build failed as:

    $ make -j16 -l16
    rm -rf obj
    gcc -c -g -o obj/CoreDumpWriter.o src/CoreDumpWriter.c -Wall -I ./include -pthread -std=gnu99
    gcc -c -g -o obj/Events.o src/Events.c -Wall -I ./include -pthread -std=gnu99
    gcc -c -g -o obj/Handle.o src/Handle.c -Wall -I ./include -pthread -std=gnu99
    gcc -c -g -o obj/Logging.o src/Logging.c -Wall -I ./include -pthread -std=gnu99
    rm -rf bin
    gcc -c -g -o obj/ProcDumpConfiguration.o src/ProcDumpConfiguration.c -Wall -I ./include -pthread -std=gnu99
    gcc -c -g -o obj/Procdump.o src/Procdump.c -Wall -I ./include -pthread -std=gnu99
    gcc -c -g -o obj/Process.o src/Process.c -Wall -I ./include -pthread -std=gnu99
    gcc -c -g -o obj/TriggerThreadProcs.o src/TriggerThreadProcs.c -Wall -I ./include -pthread -std=gnu99
    gcc -c -g -o obj/ProcDumpTestApplication.o tests/integration/ProcDumpTestApplication.c -Wall -I ./include -pthread -std=gnu99
    rm -rf /build/source/pkgbuild
    gcc -o bin/ProcDumpTestApplication obj/ProcDumpTestApplication.o -Wall -I ./include -pthread -std=gnu99
    ld: cannot open output file bin/ProcDumpTestApplication: No such file or directory
    collect2: error: ld returned 1 exit status
    make: *** [Makefile:60: bin/ProcDumpTestApplication] Error 1
    make: *** Waiting for unfinished jobs....

Note how `bin/ProcDumpTestApplication` is attempted to be created before
'bin' directory. The change adds order-only directory dependencies to all
targets that need it.

While at it:
- added `clean` dependency before each of 'mkdir -p' dependencies;
  otherwise parallel build deletes a directory after it gets created
- made directory creation targets non-silent to make incorrect deletion
  order visible