### PR TITLE
spec: fix bare words error with ProcDump 1.3 for el9

### DIFF
--- a/dist/procdump.spec.in
+++ b/dist/procdump.spec.in
@@ -3,7 +3,7 @@ Version:        @PKG_VERSION@
 Release:        %_Revision
 Summary:        Sysinternals process dump utility
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 Group:          devel
 %else
 Group:          Development/Tools%{?suse_version:/Other}
@@ -17,7 +17,7 @@ Source0:        %{url}/releases/download/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc, make
 
-%if %{_vendor} == "debbuild"
+%if "%{_vendor}" == "debbuild"
 BuildRequires:  zlib1g-dev
 %else
 BuildRequires:  zlib-devel


### PR DESCRIPTION
RPM 4.16 removed support for bare words in expressions (eg a == b needs to be a == b now). The change is backward compatible. More changes are in: https://rpm.org/wiki/Releases/4.16.0

This patch accommodates the above change and fixes more errors/warnings:
error: bare words are no longer supported, please use ...: redhat == debbuild
error: ^
error: /root/ProcDump-for-Linux/pkgbuild/SPECS/procdump.spec:6: bad %if condition: redhat == debbuild
make: *** [Makefile:91: rpm] Error 1