### PR TITLE
Add missing dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
 $(OBJDIR)/%.o: $(TESTDIR)/%.c | $(OBJDIR)
 	$(CC) -c -g -o $@ $< $(CCFLAGS)
 
-$(OUT): $(OBJS) | $(BINDIR)
+$(OUT): $(OBJS) | $(BINDIR) $(OBJDIR)/ProcDumpProfiler.so
 	$(CC) -o $@ $^ $(OBJDIR)/ProcDumpProfiler.o $(CCFLAGS)
 
 $(TESTOUT): $(TESTOBJS) | $(BINDIR)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(OBJDIR)/%.o: $(TESTDIR)/%.c | $(OBJDIR)
 	$(CC) -c -g -o $@ $< $(CCFLAGS)
 
 $(OUT): $(OBJS) | $(BINDIR) $(OBJDIR)/ProcDumpProfiler.so
-	$(CC) -o $@ $^ $(OBJDIR)/ProcDumpProfiler.o $(CCFLAGS)
+	$(CC) -o $@ $^ $(OBJDIR)/ProcDumpProfiler.o $(CCFLAGS) $(OPT_CCFLAGS)
 
 $(TESTOUT): $(TESTOBJS) | $(BINDIR)
 	$(CC) -o $@ $^ $(CCFLAGS)


### PR DESCRIPTION
Without this dependency, `ld` fails with the following error when building with parallel tasks:

    cannot find obj/ProcDumpProfiler.o: No such file or directory