### PR TITLE
Cleanup a lots of unused variables

### DIFF
--- a/src/CoreDumpWriter.cpp
+++ b/src/CoreDumpWriter.cpp
@@ -166,7 +166,6 @@ char* WriteCoreDumpInternal(struct CoreDumpWriter *self, char* socketName)
     auto_free char* gcorePrefixName = NULL;
     int  lineLength;
     int  i = 0;
-    int  rc = 0;
     pid_t gcorePid;
     FILE *commandPipe = NULL;
 
@@ -294,8 +293,6 @@ char* WriteCoreDumpInternal(struct CoreDumpWriter *self, char* socketName)
                     Log(error, "GCORE - %s", outputBuffer[j]);
                 }
             }
-
-            rc = gcoreStatus;
         }
         else
         {
@@ -324,7 +321,6 @@ char* WriteCoreDumpInternal(struct CoreDumpWriter *self, char* socketName)
                     if (self->Config->NumberOfDumpsCollected >= self->Config->NumberOfDumpsToCollect)
                     {
                         SetEvent(&self->Config->evtQuit.event); // shut it down, we're done here
-                        rc = 1;
                     }
                 }
             }

--- a/src/Monitor.cpp
+++ b/src/Monitor.cpp
@@ -65,7 +65,6 @@ void* SignalThread(void *input)
 {
     Trace("SignalThread: Enter [id=%d]", gettid());
     int sig_caught, rc;
-    struct ConfigQueueEntry * item;
 
     if ((rc = sigwait(&sig_set, &sig_caught)) != 0) {
         Log(error, "Failed to wait on signal");

--- a/src/ProcDumpConfiguration.cpp
+++ b/src/ProcDumpConfiguration.cpp
@@ -189,7 +189,6 @@ void InitProcDumpConfiguration(struct ProcDumpConfiguration *self)
     pthread_mutex_init(&self->dotnetMutex, NULL);
     pthread_cond_init(&self->dotnetCond, NULL);
 
-    long s = self->memAllocMap.size();
     if(self->memAllocMap.size() > 0)
     {
         self->memAllocMap.clear();


### PR DESCRIPTION
This commit just cleans up a lot of unused variables across the code of ProcDump. For further validation, you can compile the code with `-Wall` and `-Werror` enabled.

Some of them change the logic of the code. IMHO, it includes some code cleanups as well.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>