### PR TITLE
Getting benefits of using CMake builder for redhat based systems.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,10 @@ add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/${PROCDUMP_COMPRESS_MAN}
                    DEPENDS "${CMAKE_SOURCE_DIR}/procdump.1"
                   )
 
+install(FILES ${PROJECT_BINARY_DIR}/${PROCDUMP_COMPRESS_MAN}
+	DESTINATION "/usr/share/man/man1/"
+       )
+
 #
 # Change log
 #
@@ -290,3 +294,7 @@ add_custom_command(OUTPUT procdump_ebpf.o
                   )
 
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES procdump.ebpf.o)
+
+install(TARGETS procdump
+	DESTINATION ${CMAKE_INSTALL_BINDIR}
+       )

--- a/dist/procdump.spec.in
+++ b/dist/procdump.spec.in
@@ -39,12 +39,12 @@ general process dump utility that you can embed in other scripts.
 
 
 %build
-# The makefile doesn't like %%make_build (parallel make)
-make CFLAGS="%{optflags}"
+%cmake
+%cmake_build
 
 
 %install
-%make_install
+%cmake_install
 
 
 %files


### PR DESCRIPTION
This series just change the SPEC file template to use CMake macros in order to get full benefits for redhat systems (that use RPM packaging builds).

This series also add two `install()` sections inside CMakeLists.txt in order to install the binary file and the manpage for procdump.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>